### PR TITLE
bug #49

### DIFF
--- a/src/components/ModalConfig.vue
+++ b/src/components/ModalConfig.vue
@@ -82,7 +82,9 @@ const handleUploadedPhotos = (uploadedPhotos) => {
   const newPhotos = uploadedPhotos.map((u) =>
     u.secure_url.replace("/upload/", "/upload/c_crop,g_custom/")
   );
-  photosUrls.value = [...photosUrls.value, ...newPhotos];
+  // Lo comento por https://github.com/PIMEC-2023/crazytiles/issues/49 
+  // photosUrls.value = [...photosUrls.value, ...newPhotos];
+  photosUrls.value = newPhotos;
   setUrlsPhotos(photosUrls.value);
 };
 

--- a/src/components/ModalConfig.vue
+++ b/src/components/ModalConfig.vue
@@ -84,7 +84,7 @@ const handleUploadedPhotos = (uploadedPhotos) => {
   );
   // Lo comento por https://github.com/PIMEC-2023/crazytiles/issues/49 
   // photosUrls.value = [...photosUrls.value, ...newPhotos];
-  photosUrls.value = newPhotos;
+  photosUrls.value = [...photosUrls.value, newPhotos.slice(-1)];
   setUrlsPhotos(photosUrls.value);
 };
 


### PR DESCRIPTION
Las fotos ya no deberían duplicarse. Para probar la issue:

1. git checkout 49-issue-duplicate-images
2. git pull
3. ASegurarse que en el fichero .env tenemos todas las variables de entorno como [especificamos en Discord](https://discord.com/channels/1153665256544014426/1174620917800902696/1177940741729812510)
4. Empezar juego
5. Configuración
6. Sin cerrar la configuración, subir 3 imágenes distintas
7. Comprobar que efectivamente no se repiten